### PR TITLE
Added required header, fixed segfault bug

### DIFF
--- a/src/gen/gen_asm.cpp
+++ b/src/gen/gen_asm.cpp
@@ -6,6 +6,7 @@ This takes the intermediate reprensentation, and turns it into assembly. Also th
 #include "gen_asm.h"
 
 #include "../cli/log.h"
+#include <algorithm>
 
 // === OBJECT MANAGEMENT ===
 
@@ -58,7 +59,6 @@ void updateScope()
     const auto h = height;
     const auto before_count = scope.size();
     const auto to_remove = std::remove_if(scope.begin(), scope.end(), [&h](const auto& o){ return o.scope_height > h; });
-    scope.erase(to_remove);
     const auto after_count = scope.size();
     const auto removed_count = before_count - after_count;
     cli::log(cli::log_level::debug,"Updated scope, " + std::to_string(removed_count) + " items deleted.");


### PR DESCRIPTION
std::remove_if is defined in \<algorithm\>
scope.erase triggers a segfault since std::remove_if removes the matching elements and returns a past-the-end iterator